### PR TITLE
Write The Library Using Scala 3 Syntax Only

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,6 @@
 import ReleaseTransformations.*
 
-ThisBuild / scalaVersion := "2.13.12"
-ThisBuild / crossScalaVersions := Seq(
-  scalaVersion.value,
-  "3.3.1"
-)
+ThisBuild / scalaVersion := "3.3.1"
 ThisBuild / scalacOptions := Seq("-deprecation", "-release","11")
 ThisBuild / licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0"))
 
@@ -32,7 +28,7 @@ lazy val `duration-formatting-root` = (project in file("."))
     `spire-intervals`
   ).settings(baseSettings).settings(
     publish / skip := true,
-    releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
+    releaseCrossBuild := false, // true if you cross-build the project for multiple Scala versions
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       inquireVersions,
@@ -41,8 +37,8 @@ lazy val `duration-formatting-root` = (project in file("."))
       setReleaseVersion,
       commitReleaseVersion,
       tagRelease,
-      // For non cross-build projects, use releaseStepCommand("publishSigned")
-      releaseStepCommandAndRemaining("+publishSigned"),
+      // For cross-build projects, use releaseStepCommand("+publishSigned")
+      releaseStepCommandAndRemaining("publishSigned"),
       releaseStepCommand("sonatypeBundleRelease"),
       setNextVersion,
       commitNextVersion,

--- a/core/src/main/scala/com/gu/time/duration/formatting/DurationFormatHints.scala
+++ b/core/src/main/scala/com/gu/time/duration/formatting/DurationFormatHints.scala
@@ -5,18 +5,16 @@ import java.time.temporal.ChronoUnit
 import java.time.temporal.ChronoUnit._
 import scala.collection.immutable.{SortedMap, SortedSet}
 
-object DurationFormatHints {
-  val UnitSymbols: SortedMap[ChronoUnit, String] = SortedMap(
-    MILLIS -> "ms",
-    SECONDS -> "s",
-    MINUTES -> "m",
-    HOURS -> "h",
-    DAYS -> "d"
-  )
+val UnitSymbols: SortedMap[ChronoUnit, String] = SortedMap(
+  MILLIS -> "ms",
+  SECONDS -> "s",
+  MINUTES -> "m",
+  HOURS -> "h",
+  DAYS -> "d"
+)
 
-  val AllUsefulUnits: SortedSet[ChronoUnit] = UnitSymbols.keySet
+val AllUsefulUnits: SortedSet[ChronoUnit] = UnitSymbols.keySet
 
-  def commonSuitableSingleUnit(durations: Set[Duration]): Option[ChronoUnit] =
+extension (durations: Set[Duration])
+  def commonSuitableSingleUnit: Option[ChronoUnit] =
     durations.map(_.suitableSingleUnits).reduce(_ intersect _).maxOption
-
-}

--- a/core/src/main/scala/com/gu/time/duration/formatting/time.scala
+++ b/core/src/main/scala/com/gu/time/duration/formatting/time.scala
@@ -1,97 +1,87 @@
-package com.gu.time.duration
-
-import com.gu.time.duration.formatting.DurationFormatHints.AllUsefulUnits
+package com.gu.time.duration.formatting
 
 import java.time.Duration.{ZERO, ofDays, ofMinutes}
 import java.time.ZoneOffset.UTC
 import java.time.temporal.ChronoUnit
 import java.time.temporal.ChronoUnit.SECONDS
 import java.time.{Duration, Instant, LocalDate}
-import scala.math.Ordering.Implicits._
+import scala.math.Ordering.Implicits.*
 import scala.math.{ceil, log10}
 
+extension (duration: Duration)
+  /**
+   * The largest chronological unit that is not larger than this duration - the largest unit we would naturally use
+   * to represent the duration without rounding upwards. Eg, for 59m59s, this would be MINUTES, for 1h or 3h, it would
+   * be HOURS.
+   */
+  def largestNonZeroUnit: Option[ChronoUnit] = AllUsefulUnits.toSeq.findLast(_.getDuration <= duration)
 
-package object formatting {
+  /**
+   * Represent this duration as a series of non-zero unit amounts (eg 5 DAYS, 3 HOURS, 2 SECONDS). If the
+   * duration is zero, the series will be empty.
+   */
+  def toUnitAmounts: LazyList[UnitAmount] = largestNonZeroUnit.fold(LazyList.empty[UnitAmount]) { unit =>
+    val amount = duration.dividedBy(unit.getDuration)
+    UnitAmount(amount, unit) #:: duration.minus(unit.getDuration.multipliedBy(amount)).toUnitAmounts
+  }
 
-  implicit class RichDuration(duration: Duration) {
-
-    /**
-     * The largest chronological unit that is not larger than this duration - the largest unit we would naturally use
-     * to represent the duration without rounding upwards. Eg, for 59m59s, this would be MINUTES, for 1h or 3h, it would
-     * be HOURS.
-     */
-    val largestNonZeroUnit: Option[ChronoUnit] = AllUsefulUnits.toSeq.findLast(_.getDuration <= duration)
-
-    /**
-     * Represent this duration as a series of non-zero unit amounts (eg 5 DAYS, 3 HOURS, 2 SECONDS). If the
-     * duration is zero, the series will be empty.
-     */
-    val toUnitAmounts: LazyList[UnitAmount] = largestNonZeroUnit.fold(LazyList.empty[UnitAmount]) { unit =>
-      val amount = duration.dividedBy(unit.getDuration)
-      UnitAmount(amount, unit) #:: duration.minus(unit.getDuration.multipliedBy(amount)).toUnitAmounts
-    }
-
-    /**
-     * Format this duration as String, with a limited number of chronological units. This method never rounds upwards,
-     * so 1m59s is never expressed as '2m'.
-     *
-     * @param maxUnits starting with the most significant time unit of this duration, what is the maximum number of time
-     *                 units we want to express this time with? eg three: '6h7m8s', two: '6h7m', or one: '6h'?
-     * @param zeroUnit the unit to express a 'zero' duration in - eg, do we want '0m', or '0s'?
-     * @return
-     */
-    def format(maxUnits: Int = 2, zeroUnit: ChronoUnit = SECONDS): String = {
-      val unitAmounts = toUnitAmounts.take(maxUnits).toList
-      unitAmounts.headOption.fold(UnitAmount(0, zeroUnit).unpadded) { head =>
-        (head.unpadded +: unitAmounts.tail.map(_.padded)).mkString
-      }
-    }
-
-    /**
-     * Assuming that two durations can be accurately represented with the same single unit (allowing us to display
-     * "15–20m" or "50–60s" to concisely denote a range of duration), we can identify that unit by working out what
-     * sensible units are for each duration, and taking the the intersection of those two sets.
-     *
-     * This field works out what possible different units might desirably & accurately denote the duration, if it
-     * *can* be denoted by a single unit.
-     *
-     * If this duration can be accurately represented with a single time unit (eg 1s, or 10m, or 3h, but not 3h1s),
-     * return that unit. Additionally, if the duration exactly corresponds to 1 of that unit, also return its
-     * sub-unit (eg, for 1m, return both MINUTES & SECONDS as suitable units for expressing the duration).
-     */
-    val suitableSingleUnits: Set[ChronoUnit] = largestNonZeroUnit.fold[Set[ChronoUnit]](AllUsefulUnits) { unit =>
-      if (unit.getDuration == duration) {
-        Set(unit) ++ unit.smallerUnit // tolerate doing '60s' rather than '1m'
-      } else if (isPreciseWith(unit)) Set(unit) else Set.empty
-    }
-
-    def isPreciseWith(unit: ChronoUnit): Boolean = duration.truncatedTo(unit) == duration
-
-
-    val truncateToConcise: Duration = largestNonZeroUnit.fold(ZERO) { unit =>
-      val durationBenefitsFromSecondaryUnit = duration >= ofMinutes(1) && duration < ofDays(10)
-      duration.truncatedTo(if (durationBenefitsFromSecondaryUnit) unit.smallerOrSameIfNoSmaller else unit)
+  /**
+   * Format this duration as String, with a limited number of chronological units. This method never rounds upwards,
+   * so 1m59s is never expressed as '2m'.
+   *
+   * @param maxUnits starting with the most significant time unit of this duration, what is the maximum number of time
+   *                 units we want to express this time with? eg three: '6h7m8s', two: '6h7m', or one: '6h'?
+   * @param zeroUnit the unit to express a 'zero' duration in - eg, do we want '0m', or '0s'?
+   * @return
+   */
+  def format(maxUnits: Int = 2, zeroUnit: ChronoUnit = SECONDS): String = {
+    val unitAmounts = toUnitAmounts.take(maxUnits).toList
+    unitAmounts.headOption.fold(UnitAmount(0, zeroUnit).unpadded) { head =>
+      (head.unpadded +: unitAmounts.tail.map(_.padded)).mkString
     }
   }
 
-  implicit class RichInstant(instant: Instant) {
-    lazy val utcLocalDate: LocalDate = instant.atZone(UTC).toLocalDate
-    lazy val utcEpochDay: Long = utcLocalDate.toEpochDay
+  /**
+   * Assuming that two durations can be accurately represented with the same single unit (allowing us to display
+   * "15–20m" or "50–60s" to concisely denote a range of duration), we can identify that unit by working out what
+   * sensible units are for each duration, and taking the the intersection of those two sets.
+   *
+   * This field works out what possible different units might desirably & accurately denote the duration, if it
+   * *can* be denoted by a single unit.
+   *
+   * If this duration can be accurately represented with a single time unit (eg 1s, or 10m, or 3h, but not 3h1s),
+   * return that unit. Additionally, if the duration exactly corresponds to 1 of that unit, also return its
+   * sub-unit (eg, for 1m, return both MINUTES & SECONDS as suitable units for expressing the duration).
+   */
+  def suitableSingleUnits: Set[ChronoUnit] = largestNonZeroUnit.fold[Set[ChronoUnit]](AllUsefulUnits) { unit =>
+    if (unit.getDuration == duration) {
+      Set(unit) ++ unit.smallerUnit // tolerate doing '60s' rather than '1m'
+    } else if (isPreciseWith(unit)) Set(unit) else Set.empty
   }
 
-  implicit class RichChronoUnit(chronoUnit: ChronoUnit) {
-    val symbol: String = DurationFormatHints.UnitSymbols.getOrElse(chronoUnit, nameSingular)
-    val namePlural: String = chronoUnit.name.toLowerCase
-    val nameSingular: String = namePlural.stripSuffix("s")
+  def isPreciseWith(unit: ChronoUnit): Boolean = duration.truncatedTo(unit) == duration
 
-    val smallerUnit: Option[ChronoUnit] = AllUsefulUnits.maxBefore(chronoUnit)
-    val biggerUnit: Option[ChronoUnit] = AllUsefulUnits.minAfter(chronoUnit)
-    val smallerOrSameIfNoSmaller: ChronoUnit = smallerUnit.getOrElse(chronoUnit)
 
-    val padDigits: Int =
-      biggerUnit.map(bu => ceil(log10(bu.getDuration.dividedBy(chronoUnit.getDuration).toDouble)).toInt).getOrElse(1)
-
-    // new DecimalFormat("00").format(l)
-    def pad(amount: Long): String = s"%02d".format(amount)
+  def truncateToConcise: Duration = largestNonZeroUnit.fold(ZERO) { unit =>
+    val durationBenefitsFromSecondaryUnit = duration >= ofMinutes(1) && duration < ofDays(10)
+    duration.truncatedTo(if (durationBenefitsFromSecondaryUnit) unit.smallerOrSameIfNoSmaller else unit)
   }
-}
+
+extension (chronoUnit: ChronoUnit)
+  def symbol: String = UnitSymbols.getOrElse(chronoUnit, nameSingular)
+  def namePlural: String = chronoUnit.name.toLowerCase
+  def nameSingular: String = namePlural.stripSuffix("s")
+
+  def smallerUnit: Option[ChronoUnit] = AllUsefulUnits.maxBefore(chronoUnit)
+  def biggerUnit: Option[ChronoUnit] = AllUsefulUnits.minAfter(chronoUnit)
+  def smallerOrSameIfNoSmaller: ChronoUnit = smallerUnit.getOrElse(chronoUnit)
+
+  def padDigits: Int =
+    biggerUnit.map(bu => ceil(log10(bu.getDuration.dividedBy(chronoUnit.getDuration).toDouble)).toInt).getOrElse(1)
+
+  // new DecimalFormat("00").format(l)
+  def pad(amount: Long): String = s"%02d".format(amount)
+  
+extension (instant: Instant)
+  def utcLocalDate: LocalDate = instant.atZone(UTC).toLocalDate
+  def utcEpochDay: Long = utcLocalDate.toEpochDay

--- a/core/src/test/scala/com/gu/time/duration/formatting/DurationFormatHintsTest.scala
+++ b/core/src/test/scala/com/gu/time/duration/formatting/DurationFormatHintsTest.scala
@@ -1,6 +1,5 @@
 package com.gu.time.duration.formatting
 
-import com.gu.time.duration.formatting.DurationFormatHints.AllUsefulUnits
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/spire-intervals/src/main/scala/com/gu/time/duration/formatting/AgeDisplayMoreExact.scala
+++ b/spire-intervals/src/main/scala/com/gu/time/duration/formatting/AgeDisplayMoreExact.scala
@@ -6,9 +6,9 @@ import spire.math._
 import java.time.Duration
 import java.time.temporal.ChronoUnit._
 
-object AgeDisplayMoreExact {
+given Order[Duration] = Order.fromOrdering
 
-  implicit val durationOrder: Order[Duration] = Order.fromOrdering
+object AgeDisplayMoreExact {
 
   def print(d: Duration): String = {
     d.truncatedTo(SECONDS).truncateToConcise.format(2)
@@ -21,7 +21,7 @@ object AgeDisplayMoreExact {
     case Bounded(lower, upper, _) =>
       val bounds = Seq(lower, upper)
       def both(f: Duration => _): String = bounds.map(f).mkString("–")
-      DurationFormatHints.commonSuitableSingleUnit(bounds.toSet).fold(both(print)) { commonUnit =>
+      bounds.toSet.commonSuitableSingleUnit.fold(both(print)) { commonUnit =>
         both(_.dividedBy(commonUnit.getDuration)) + commonUnit.symbol
       }
     case _ => durationRange.toString // All or Empty! Unlikely to reach this case, but at least it's readable


### PR DESCRIPTION
- Set the main scala version to 3.3.1 and dropped cross-compilation.
- Made use of `extension`s rather than `implicit class`es
- Moved some `val`s out of `object`s to the top level of their files
- Use `*` for wildcard imports instead of `_`
- Use `given` rather than `implicit val`

Paired with @rtyley 
